### PR TITLE
fix: Implement say command evaluation and standardize runtime errors

### DIFF
--- a/kidcode-core/src/main/java/com/kidcode/core/evaluator/Evaluator.java
+++ b/kidcode-core/src/main/java/com/kidcode/core/evaluator/Evaluator.java
@@ -40,7 +40,7 @@ public class Evaluator {
         if (stmt instanceof SetStatement setStmt) {
             Object value = evaluateExpression(setStmt.value(), env);
             if (isError(value)) {
-                events.add(new ExecutionEvent.SayEvent((String) value));
+                events.add(new ExecutionEvent.ErrorEvent((String) value));
             } else {
                 env.set(setStmt.name().value(), value);
             }
@@ -83,6 +83,13 @@ public class Evaluator {
             }
             env.setPenColor(colorName.toLowerCase());
             events.add(new ExecutionEvent.MoveEvent(env.getX(), env.getY(), env.getX(), env.getY(), env.getDirection(), env.isPenDown(), env.getPenColor()));
+        } else if (stmt instanceof SayStatement sayStmt) {
+            Object messageObj = evaluateExpression(sayStmt.message(), env);
+            if (isError(messageObj)) {
+                events.add(new ExecutionEvent.ErrorEvent((String) messageObj));  // Use ErrorEvent for consistency
+            } else {
+                events.add(new ExecutionEvent.SayEvent(String.valueOf(messageObj)));
+            }
         } else if (stmt instanceof RepeatStatement repeatStmt) {
             Object timesVal = evaluateExpression(repeatStmt.times(), env);
             if (!(timesVal instanceof Integer times)) {


### PR DESCRIPTION
## Summary
This PR fixes the `say` command not producing any output during execution. The root cause was a missing `instanceof SayStatement` case in the `Evaluator` class, causing say statements to be silently ignored at runtime (parsing worked fine, no events emitted).

Additionally, it standardizes runtime error handling by using `ExecutionEvent.ErrorEvent` instead of misusing `SayEvent` for errors in statements like `SetStatement`. This ensures consistent error display across UIs (e.g., "ERROR: ..." in red, not as a "Cody says" message).

Closes #1 

## Changes
- **kidcode-core/src/main/java/com/kidcode/core/evaluator/Evaluator.java**:
  - Added `else if (stmt instanceof SayStatement sayStmt)` block:
    - Evaluates the message expression.
    - Emits `SayEvent` with `String.valueOf(messageObj)` on success.
    - Emits `ErrorEvent` if evaluation fails (e.g., undefined var).
  - Updated `SetStatement` handling to use `ErrorEvent` for type/errors.
  - (Optional future: Apply similar ErrorEvent fix to Move/Turn/Pen/Color statements for full consistency.)

## Why This Fixes It
- The parser correctly creates `SayStatement` AST nodes (via `parseSayStatement()`).
- Engine now processes them, adding events to the list consumed by:
  - CLI: Prints "Cody says: ...".
  - Desktop GUI: Appends to outputArea.
  - Web: Logs to output-area via renderEvents().
- No parse errors; runtime now works for scripts like `simple_test.kc`, `debug_test.kc`, etc.

## Testing Done
- **Build**: `mvn clean package` at root – succeeds.
- **Unit/Integration**:
  - CLI: `mvn exec:java -Dexec.mainClass="com.kidcode.cli.CommandLineRunner" -Dexec.args="../test_scripts/simple_test.kc"` → Outputs "Cody says: Simple test" and "Cody says: Hello from function".
  - Desktop: Load `simple_test.kc` in GUI, click Run → Messages appear in output panel.
  - Web: `mvn spring-boot:run -pl kidcode-web`, paste code with `say "Hello"`, run → "Cody says: Hello" in log.
- **Edge Cases**:
  - `say 5 + 5` → "10".
  - `say undefinedVar` → "ERROR: variable 'undefinedVar' not found.".
  - `say "Hello" + " World"` → "Hello World".
  - Invalid: `say` without arg → Parse error (already handled).
- No regressions: Move, turn, repeat, functions, lists still work (tested with `test_functions_lists.kc`).

## Additional Notes
- This keeps the core headless and event-driven – UIs unchanged.
- If expanding, consider adding more ErrorEvent usage in other statements.
- Ready for review/merge. CI should pass if tests are added (none currently, but manual verification solid).