### PR TITLE
feat: implement local storage for code saving and loading

### DIFF
--- a/kidcode-web/src/main/resources/static/app.js
+++ b/kidcode-web/src/main/resources/static/app.js
@@ -10,6 +10,9 @@ const helpButton = document.getElementById('help-button');
 const helpModal = document.getElementById('help-modal');
 const closeButton = document.querySelector('.close-button');
 
+// --- Key for browser's local storage ---
+const KIDCODE_STORAGE_KEY = 'kidcode.savedCode';
+
 // --- MONACO: Global variable to hold the editor instance ---
 let editor;
 let validationTimeout;
@@ -50,8 +53,9 @@ require.config({ paths: { 'vs': 'https://cdn.jsdelivr.net/npm/monaco-editor@0.34
 require(['vs/editor/editor.main'], function() {
     registerKidCodeLanguage();
 
-        editor = monaco.editor.create(editorContainer, {
-                    value: [
+        // --- Load code from localStorage or use default ---
+        const savedCode = localStorage.getItem(KIDCODE_STORAGE_KEY);
+        const defaultCode = [
             '# Welcome to KidCode!',
             '# Run this code to see a rainbow spiral, then try changing it!',
             '',
@@ -76,7 +80,10 @@ require(['vs/editor/editor.main'], function() {
             '        set color_index = 0',
             '    end if',
             'end repeat'
-        ].join('\n'),
+        ].join('\n');
+
+        editor = monaco.editor.create(editorContainer, {
+            value: savedCode !== null ? savedCode : defaultCode,
             language: 'kidcode',
             theme: 'vs-light',
             automaticLayout: true,
@@ -99,8 +106,12 @@ require(['vs/editor/editor.main'], function() {
             }
         });
 
-    // MONACO: Live validation
+    // MONACO: Live validation and auto-saving
     editor.onDidChangeModelContent(() => {
+        // Save the current code to local storage
+        localStorage.setItem(KIDCODE_STORAGE_KEY, editor.getValue());
+
+        // Debounce validation
         clearTimeout(validationTimeout);
         validationTimeout = setTimeout(validateCode, 500);
     });


### PR DESCRIPTION
This pull address part of issue #22 by introducing a feature to automatically save the user's code from the editor into the browser's localStorage. When a user revisits the application, their most recent code is automatically loaded, preventing any loss of work between sessions.

This addresses the issue of users losing their code upon refreshing or closing the browser tab.

# Changes Implemented:

- Auto-Saving: The editor's content is saved to localStorage under the key kidcode.savedCode whenever the user makes a change (onDidChangeModelContent event).
- Auto-Loading: On application startup, the editor checks for saved code in localStorage. If found, it's loaded into the editor.
- Default Fallback: If no saved code is found (i.e., a first-time visit), the default "rainbow spiral" example code is loaded as usual.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Automatically saves your code in the browser and restores it when you return.
  * Provides default starter code when no saved code is available.
* Improvements
  * Smoother live validation with a short delay to reduce interruptions while typing.
  * Updated editor experience with clearer font sizing and a simplified view (minimap disabled).
* Notes
  * Run and Validate actions continue to work as before, now with persistence and improved editing flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->