### PR TITLE
feat(web): add Download Drawing button to export canvas as PNG

### DIFF
--- a/kidcode-web/src/main/resources/static/app.js
+++ b/kidcode-web/src/main/resources/static/app.js
@@ -9,6 +9,8 @@ const ctx = drawingCanvas.getContext('2d');
 const helpButton = document.getElementById('help-button');
 const helpModal = document.getElementById('help-modal');
 const closeButton = document.querySelector('.close-button');
+const downloadButton = document.getElementById('download-btn');
+
 
 // --- MONACO: Global variable to hold the editor instance ---
 let editor;
@@ -127,6 +129,23 @@ runButton.addEventListener('click', async () => {
         logToOutput(`Network or server error: ${error.message}`, 'error');
     }
 });
+
+// --- NEW: Event listener for Download button ---
+if (downloadButton) {
+    downloadButton.addEventListener('click', () => {
+        try {
+            const imageURL = drawingCanvas.toDataURL('image/png');
+            const link = document.createElement('a');
+            link.href = imageURL;
+            link.download = 'CodyDrawing.png';
+            link.click();
+            logToOutput('Drawing exported as CodyDrawing.png');
+        } catch (err) {
+            logToOutput(`Failed to export drawing: ${err.message}`, 'error');
+        }
+    });
+}
+
 
 // --- NEW: Function to handle validation ---
 async function validateCode() {

--- a/kidcode-web/src/main/resources/static/index.html
+++ b/kidcode-web/src/main/resources/static/index.html
@@ -41,6 +41,9 @@
         <div class="visual-panel">
             <div class="panel-header">
                 <h3>Cody's Canvas</h3>
+                <div>
+                    <button id="download-btn">Download Drawing</button>
+                </div>
             </div>
             <canvas id="drawing-canvas" width="500" height="500"></canvas>
         </div>

--- a/kidcode-web/src/main/resources/static/style.css
+++ b/kidcode-web/src/main/resources/static/style.css
@@ -314,3 +314,28 @@ footer {
 #help-docs th {
   background-color: #f2f2f2;
 }
+
+#download-btn {
+  background: linear-gradient(145deg, #f39c12 0%, #e67e22 100%);
+  color: white;
+  border: none;
+  border-radius: 10px;
+  padding: 10px 20px;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 0 4px 8px rgba(243, 156, 18, 0.25);
+  transition: all 0.25s ease;
+}
+
+#download-btn:hover {
+  background: linear-gradient(145deg, #f1c40f 0%, #f39c12 100%);
+  transform: translateY(-2px) scale(1.02);
+  box-shadow: 0 6px 14px rgba(241, 196, 15, 0.35);
+}
+
+#download-btn:active {
+  background: linear-gradient(145deg, #d68910 0%, #b9770e 100%);
+  transform: translateY(0) scale(0.98);
+  box-shadow: 0 3px 6px rgba(243, 156, 18, 0.2);
+}
+


### PR DESCRIPTION
Closes #30 
Adds a button to download the current canvas drawing as a PNG file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Download Drawing button in Cody’s Canvas to export the current canvas as a PNG (CodyDrawing.png).
  * Includes success feedback and safeguards to avoid errors if the button is unavailable.

* **Style**
  * Introduced polished, interactive styling for the download button with hover and active states (gradients, shadows, subtle transforms) for improved visual feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->