### PR TITLE
Clear button added  next to Run

### DIFF
--- a/kidcode-web/src/main/resources/static/app.js
+++ b/kidcode-web/src/main/resources/static/app.js
@@ -2,6 +2,7 @@
 
 // --- 1. GET REFERENCES TO OUR HTML ELEMENTS ---
 const runButton = document.getElementById('run-button');
+const clearButton = document.getElementById('clearBtn');
 const editorContainer = document.getElementById('editor-container');
 const drawingCanvas = document.getElementById('drawing-canvas');
 const outputArea = document.getElementById('output-area');
@@ -128,6 +129,27 @@ runButton.addEventListener('click', async () => {
     }
 });
 
+// --- 🧹 NEW: ADD EVENT LISTENER TO CLEAR BUTTON ---
+clearButton.addEventListener('click', () => {
+    try {
+        // 1️⃣ Clear the Monaco editor
+        if (editor && typeof editor.setValue === 'function') {
+            editor.setValue('');
+        }
+
+        // 2️⃣ Clear the output log
+        if (outputArea) outputArea.textContent = '';
+
+        // 3️⃣ Clear the drawing canvas
+        clearCanvas();
+
+        // 4️⃣ Feedback message
+        logToOutput('✨ Cleared editor, canvas, and output!');
+    } catch (error) {
+        logToOutput(`Error while clearing: ${error.message}`, 'error');
+    }
+});
+
 // --- NEW: Function to handle validation ---
 async function validateCode() {
     const code = editor.getValue();
@@ -248,4 +270,4 @@ window.addEventListener('click', (event) => {
     if (event.target === helpModal) {
         helpModal.classList.add('hidden');
     }
-}); 
+});

--- a/kidcode-web/src/main/resources/static/index.html
+++ b/kidcode-web/src/main/resources/static/index.html
@@ -20,6 +20,7 @@
                 <div>
                     <button id="help-button">Help</button>
                     <button id="run-button">▶ Run</button>
+                    <button id="clearBtn">Clear</button>
                 </div>
             </div>
             <!-- MONACO: Replace textarea with a div container -->

--- a/kidcode-web/src/main/resources/static/style.css
+++ b/kidcode-web/src/main/resources/static/style.css
@@ -132,7 +132,9 @@ footer {
 }
 
 .panel-header > div {
-    display: flex;
+  display: flex;
+  align-items: center;
+  gap: 12px;
 }
 
 .modal {
@@ -207,3 +209,30 @@ footer {
 #help-docs th {
     background-color: #f2f2f2;
 } 
+/* 🧹 Clear Button – Consistent with Run and Help */
+#clearBtn {
+  background-color: #f8f9fa;
+  color: #e67e22;
+  border: 2px solid #e67e22;
+  border-radius: 8px;
+  padding: 0 20px;
+  height: 42px;
+  font-weight: 600;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: all 0.25s ease;
+  box-shadow: 0 3px 6px rgba(230, 126, 34, 0.25);
+}
+
+#clearBtn:hover {
+  background-color: #e67e22;
+  color: white;
+  transform: translateY(-2px) scale(1.02);
+  box-shadow: 0 6px 12px rgba(230, 126, 34, 0.35);
+}
+
+#clearBtn:active {
+  background-color: #ca6f1e;
+  transform: translateY(0) scale(0.98);
+  box-shadow: 0 2px 4px rgba(230, 126, 34, 0.25);
+}


### PR DESCRIPTION
## Added Clear Button Functionality to Code Editor

### Summary:
Implemented a new "Clear" button next to the Run and Help buttons in the Code Editor panel.
This button resets the editor, output log, and drawing canvas — improving usability for users who want to quickly start fresh without reloading the page.

### Changes Made:
- Added a new 🧹 Clear button in index.html.
- Updated app.js to clear the editor content, output area, and canvas on click.
- Styled the button in style.css for visual consistency with Run and Help buttons.
- Adjusted .panel-header > div layout to add spacing between buttons.

### Preview:
The Clear button now appears beside Run and Help with matching UI styling.
Part of:
“Modernize and Enhance the Web Application UI/UX”
→ Specifically implements: “Implement a Clear Button” task


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Clear button in the Code Editor header. Clicking it instantly clears the editor, output area, and canvas, with confirmation feedback and error handling.

* **Style**
  * Introduced themed styles for the Clear button, including hover and active states.
  * Adjusted header alignment and spacing for improved layout consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->