### PR TITLE
fix: coderabbit language

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -3,7 +3,7 @@
 # For all configuration options, see the official docs: https://www.coderabbit.ai/docs/configuration
 
 # Set the primary language of the project. This helps the AI provide more accurate feedback.
-language: "java"
+language: "en-US"
 
 # --- Pull Request Review Settings ---
 reviews:


### PR DESCRIPTION
# Context
Code rabbit runs into a validation error in #44, because the language shouldn't be `java`, it should be a natural language. According to [the documentation](https://docs.coderabbit.ai/reference/configuration#param-language) the language key is used for docstrings. I couldn't find anything specifically how to setup coderabbits main programming language, but it seems that it detects it automatically based on the file suffix e.g. `.java`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration settings to reflect language preference adjustments.

---

**Note:** This release contains infrastructure updates with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->